### PR TITLE
feat(CO-32): responsive register page

### DIFF
--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-sm">
-  <div class="container">
+  <div class="container registerNav">
     <h1 class="navbar-text">Hero Manager</h1>
     <li class="navbar-nav ml-auto">
       <a type="button" class="nav-link" (click)="cancelRegistration()">Login</a>

--- a/src/app/components/register/register.component.scss
+++ b/src/app/components/register/register.component.scss
@@ -56,3 +56,22 @@ form {
 .form-group > h5 {
   color: green;
 }
+
+@media only screen and (max-width: 416px) {
+  .registerPage .card {
+    width: 90%;
+  }
+
+  .registerNav > li {
+    visibility: hidden;
+    position: absolute;
+  }
+
+  .registerNav {
+    justify-content: center;
+  }
+
+  .registerPage h1 {
+    font-size: 1.5em;
+  }
+}


### PR DESCRIPTION
Added mobile view to the end of register page comopnent.scss
On mobile view, the "hero manager" title appears in the middle and the login button disappears from the navbar/top